### PR TITLE
Docker Compose 를 사용하여 MySQL 컨테이너 설정 구현

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  database:
+    container_name: mysql
+    image: mysql:8
+    restart: unless-stopped
+    environment:
+      TZ: Asia/Seoul
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: fukufuku
+    ports:
+      - 3307:3306

--- a/src/common/guard/refresh.guard.ts
+++ b/src/common/guard/refresh.guard.ts
@@ -67,6 +67,7 @@ export class RefreshGuard implements CanActivate {
 
   // 구글로그인 경로로 redirect
   async reLogin(response: Response) {
+    response.set('access-control-allow-origin', 'http://localhost:5173');
     const loginUrl = this.configService.get<string>('GOAUTH_RELOGIN_URL');
     response.redirect(loginUrl);
   }


### PR DESCRIPTION
### Docker Compose를 사용하여 MySQL 컨테이너를 설정하고 실행하도록 구현했습니다. 
- 컨테이너 이름: mysql
- 이미지: mysql:8
- 타임존: Asia/Seoul
- 루트 비밀번호: test
- 데이터베이스 이름: fukufuku
- 포트 매핑: 호스트의 3307 포트에서 컨테이너의 3306 포트로


### 실행 방법
``` shell
// Docker Compose를 사용하여 MySQL 데이터베이스를 간단히 실행할 수 있습니다.
docker-compose -f ./docker-compose.db.yml up -d

// 새롭게 연결된 MySQL 컨테이너에 prisma 모델 정의를 기반으로 스키마를 업데이트 해줍니다.
npx prisma db push
```
