### PR TITLE
이미지 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/jwt": "^10.1.0",
     "@nestjs/mapped-types": "^2.0.2",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^4.0.1",
     "@prisma/client": "^4.16.2",
     "@types/dotenv": "^8.2.0",
     "aws-sdk": "^2.1415.0",

--- a/prisma/migrations/20240325012045_alter_image_table/migration.sql
+++ b/prisma/migrations/20240325012045_alter_image_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `expiredAt` to the `Image` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `image` ADD COLUMN `expiredAt` DATETIME(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ model Reply {
 model Image {
   url String @id @db.VarChar(100)
   key String
+  expiredAt DateTime
 }
 
 model UserImage {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,21 +1,22 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
-import { ConfigModule } from '@nestjs/config';
-import { AuthModule } from './auth/auth.module';
-import { UserModule } from './user/user.module';
-import { BoardsModule } from './boards/boards.module';
-import { CommentsModule } from './comments/comments.module';
-import { ReplysModule } from './replys/replys.module';
-import { LikeModule } from './like/like.module';
-import { TagsModule } from './tags/tags.module';
-import { BoardTagsModule } from './board-tags/board-tags.module';
-import { UploadModule } from './upload/upload.module';
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { ConfigModule } from "@nestjs/config";
+import { AuthModule } from "./auth/auth.module";
+import { UserModule } from "./user/user.module";
+import { BoardsModule } from "./boards/boards.module";
+import { CommentsModule } from "./comments/comments.module";
+import { ReplysModule } from "./replys/replys.module";
+import { LikeModule } from "./like/like.module";
+import { TagsModule } from "./tags/tags.module";
+import { BoardTagsModule } from "./board-tags/board-tags.module";
+import { UploadModule } from "./upload/upload.module";
+import { ScheduleModule } from "@nestjs/schedule";
 
 @Module({
   imports: [
     ConfigModule.forRoot({
-      envFilePath: '.env',
+      envFilePath: ".env",
       isGlobal: true,
     }),
     AuthModule,
@@ -27,6 +28,7 @@ import { UploadModule } from './upload/upload.module';
     TagsModule,
     BoardTagsModule,
     UploadModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -26,9 +26,6 @@ export class UploadController {
     // 이미지 업로드
     const result = await this.uploadService.upload(req);
 
-    // 비동기적으로 이미지 체크
-    this.uploadService.check(result);
-
     return { url: result.url };
   }
 

--- a/src/upload/upload.repository.ts
+++ b/src/upload/upload.repository.ts
@@ -25,6 +25,17 @@ export class UploadRepository {
       data: {
         url,
         key,
+        expiredAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      },
+    });
+  }
+
+  async getAllTempImage() {
+    return this.prisma.image.findMany({
+      where: {
+        expiredAt: {
+          lt: new Date(),
+        },
       },
     });
   }


### PR DESCRIPTION
quill을 통해 이미지를 업로드할때 게시글 작성이 되지 않고, 이미지가 참조되지 않더라도 여전히 s3객체로 남아 스토리지를 낭비하는 문제가 있었습니다.

### 해결 과정
1. 이미지를 등록할 때 임시 이미지로서 만료기간을 설정해 db에 저장합니다.
2. 글이 등록될 때 임시 이미지로서 등록된 데이터를 삭제합니다.
3. 스케줄러를 설정해 만료된 이미지를 찾고, 해당 이미지들을 삭제하도록 했습니다.